### PR TITLE
Feat/자체 로그인

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -38,6 +38,10 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	runtimeOnly 'com.mysql:mysql-connector-j'
 
+	// Jwt
+	implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
+	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
+	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
 
 	//lombok 추가
 	compileOnly 'org.projectlombok:lombok'

--- a/build.gradle
+++ b/build.gradle
@@ -32,7 +32,7 @@ dependencies {
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 
 	// Spring Security
-//	implementation 'org.springframework.boot:spring-boot-starter-security'
+	implementation 'org.springframework.boot:spring-boot-starter-security'
 
 	// MySQL
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'

--- a/src/main/java/com/hackathon/wagle/WagleApplication.java
+++ b/src/main/java/com/hackathon/wagle/WagleApplication.java
@@ -2,8 +2,10 @@ package com.hackathon.wagle;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
+@EnableJpaAuditing
 public class WagleApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/com/hackathon/wagle/domain/user/controller/SuccessMessage.java
+++ b/src/main/java/com/hackathon/wagle/domain/user/controller/SuccessMessage.java
@@ -7,6 +7,7 @@ import lombok.Getter;
 @AllArgsConstructor
 public enum SuccessMessage {
 
+    USER_LOGIN("로그인에 성공했습니다!"),
     USER_CREATED("회원가입에 성공했습니다!");
 
     private final String message;

--- a/src/main/java/com/hackathon/wagle/domain/user/controller/SuccessMessage.java
+++ b/src/main/java/com/hackathon/wagle/domain/user/controller/SuccessMessage.java
@@ -1,0 +1,13 @@
+package com.hackathon.wagle.domain.user.controller;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum SuccessMessage {
+
+    USER_CREATED("회원가입에 성공했습니다!");
+
+    private final String message;
+}

--- a/src/main/java/com/hackathon/wagle/domain/user/controller/UserController.java
+++ b/src/main/java/com/hackathon/wagle/domain/user/controller/UserController.java
@@ -1,0 +1,29 @@
+package com.hackathon.wagle.domain.user.controller;
+
+import com.hackathon.wagle.domain.user.dto.request.UserRequestDto;
+import com.hackathon.wagle.domain.user.entity.User;
+import com.hackathon.wagle.domain.user.service.UserService;
+import com.hackathon.wagle.global.common.response.ApiResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+import static com.hackathon.wagle.domain.user.controller.SuccessMessage.USER_CREATED;
+import static org.springframework.http.HttpStatus.OK;
+
+@RestController
+@RequiredArgsConstructor
+public class UserController {
+
+    private final UserService userService;
+
+    @PostMapping("/api/user")
+    public ApiResponse<Void> register(@RequestBody UserRequestDto dto) {
+
+        userService.saveUser(dto);
+
+        return ApiResponse.response(OK, USER_CREATED.getMessage());
+    }
+
+}

--- a/src/main/java/com/hackathon/wagle/domain/user/controller/UserController.java
+++ b/src/main/java/com/hackathon/wagle/domain/user/controller/UserController.java
@@ -1,7 +1,8 @@
 package com.hackathon.wagle.domain.user.controller;
 
 import com.hackathon.wagle.domain.user.dto.request.UserRequestDto;
-import com.hackathon.wagle.domain.user.entity.User;
+import com.hackathon.wagle.domain.user.dto.request.UserLoginDto;
+import com.hackathon.wagle.domain.user.dto.response.LoginDto;
 import com.hackathon.wagle.domain.user.service.UserService;
 import com.hackathon.wagle.global.common.response.ApiResponse;
 import lombok.RequiredArgsConstructor;
@@ -10,6 +11,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 
 import static com.hackathon.wagle.domain.user.controller.SuccessMessage.USER_CREATED;
+import static com.hackathon.wagle.domain.user.controller.SuccessMessage.USER_LOGIN;
 import static org.springframework.http.HttpStatus.OK;
 
 @RestController
@@ -24,6 +26,15 @@ public class UserController {
         userService.saveUser(dto);
 
         return ApiResponse.response(OK, USER_CREATED.getMessage());
+    }
+
+    @PostMapping("/api/login")
+    public ApiResponse<LoginDto> login(@RequestBody UserLoginDto dto) {
+
+        LoginDto response = userService.login(dto);
+
+
+        return ApiResponse.response(OK, USER_LOGIN.getMessage(), response);
     }
 
 }

--- a/src/main/java/com/hackathon/wagle/domain/user/dto/request/UserLoginDto.java
+++ b/src/main/java/com/hackathon/wagle/domain/user/dto/request/UserLoginDto.java
@@ -1,0 +1,7 @@
+package com.hackathon.wagle.domain.user.dto.request;
+
+public record UserLoginDto(
+        String studentNumber,
+        String password
+) {
+}

--- a/src/main/java/com/hackathon/wagle/domain/user/dto/request/UserRequestDto.java
+++ b/src/main/java/com/hackathon/wagle/domain/user/dto/request/UserRequestDto.java
@@ -1,0 +1,10 @@
+package com.hackathon.wagle.domain.user.dto.request;
+
+public record UserRequestDto(
+        String username,
+        String studentNumber,
+        String major,
+        String email,
+        String password
+) {
+}

--- a/src/main/java/com/hackathon/wagle/domain/user/dto/response/LoginDto.java
+++ b/src/main/java/com/hackathon/wagle/domain/user/dto/response/LoginDto.java
@@ -1,0 +1,16 @@
+package com.hackathon.wagle.domain.user.dto.response;
+
+import lombok.Builder;
+
+@Builder
+public record LoginDto(
+        UserResponseDto user,
+        String token
+) {
+    public static LoginDto of(UserResponseDto user, String token) {
+        return LoginDto.builder()
+                .user(user)
+                .token(token)
+                .build();
+    }
+}

--- a/src/main/java/com/hackathon/wagle/domain/user/dto/response/UserResponseDto.java
+++ b/src/main/java/com/hackathon/wagle/domain/user/dto/response/UserResponseDto.java
@@ -1,0 +1,24 @@
+package com.hackathon.wagle.domain.user.dto.response;
+
+import com.hackathon.wagle.domain.user.entity.User;
+import com.hackathon.wagle.domain.user.entity.enums.Role;
+import lombok.Builder;
+
+@Builder
+public record UserResponseDto(
+         String username,
+         String major,
+         String studentNumber,
+         String email,
+         Role role
+) {
+    public static UserResponseDto from(User user) {
+        return UserResponseDto.builder()
+                .username(user.getUsername())
+                .major(user.getMajor())
+                .studentNumber(user.getStudentNumber())
+                .email(user.getEmail())
+                .role(user.getRole())
+                .build();
+    }
+}

--- a/src/main/java/com/hackathon/wagle/domain/user/entity/User.java
+++ b/src/main/java/com/hackathon/wagle/domain/user/entity/User.java
@@ -1,0 +1,44 @@
+package com.hackathon.wagle.domain.user.entity;
+
+
+import com.hackathon.wagle.domain.user.dto.request.UserRequestDto;
+import com.hackathon.wagle.domain.user.entity.enums.Role;
+import com.hackathon.wagle.global.common.entity.BaseEntity;
+import jakarta.persistence.*;
+import lombok.*;
+import lombok.experimental.SuperBuilder;
+
+import static com.hackathon.wagle.domain.user.entity.enums.Role.MEMBER;
+
+@Getter
+@Entity
+@Table
+@SuperBuilder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class User extends BaseEntity {
+
+    private String username;
+
+    private String major;
+
+    private String studentNumber;
+
+    private String email;
+
+    private String password;
+
+    @Enumerated(EnumType.STRING)
+    private Role role;
+
+    public static User of(UserRequestDto dto) {
+        return User.builder()
+                .username(dto.username())
+                .major(dto.major())
+                .studentNumber(dto.studentNumber())
+                .email(dto.email())
+                .password(dto.password())
+                .role(MEMBER)
+                .build();
+    }
+
+}

--- a/src/main/java/com/hackathon/wagle/domain/user/entity/enums/Role.java
+++ b/src/main/java/com/hackathon/wagle/domain/user/entity/enums/Role.java
@@ -1,0 +1,5 @@
+package com.hackathon.wagle.domain.user.entity.enums;
+
+public enum Role {
+    MEMBER, ADMIN
+}

--- a/src/main/java/com/hackathon/wagle/domain/user/exception/DuplicatedStudentNumberException.java
+++ b/src/main/java/com/hackathon/wagle/domain/user/exception/DuplicatedStudentNumberException.java
@@ -1,0 +1,13 @@
+package com.hackathon.wagle.domain.user.exception;
+
+import com.hackathon.wagle.global.common.exception.BaseException;
+import org.springframework.http.HttpStatus;
+
+import static com.hackathon.wagle.domain.user.exception.ErrorMessage.STUDENT_NUMBER_DUPLICATE;
+import static org.springframework.http.HttpStatus.BAD_REQUEST;
+
+public class DuplicatedStudentNumberException extends BaseException {
+    public DuplicatedStudentNumberException() {
+        super(BAD_REQUEST, STUDENT_NUMBER_DUPLICATE.getMessage());
+    }
+}

--- a/src/main/java/com/hackathon/wagle/domain/user/exception/ErrorMessage.java
+++ b/src/main/java/com/hackathon/wagle/domain/user/exception/ErrorMessage.java
@@ -1,0 +1,15 @@
+package com.hackathon.wagle.domain.user.exception;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum ErrorMessage {
+
+    STUDENT_NUMBER_DUPLICATE("중복되는 학번입니다."),
+    USER_NOT_FOUND("사용자를 찾을 수 없습니다");
+
+
+    private final String message;
+}

--- a/src/main/java/com/hackathon/wagle/domain/user/exception/UserNotFoundException.java
+++ b/src/main/java/com/hackathon/wagle/domain/user/exception/UserNotFoundException.java
@@ -1,0 +1,15 @@
+package com.hackathon.wagle.domain.user.exception;
+
+import com.hackathon.wagle.global.common.exception.BaseException;
+import org.antlr.v4.runtime.BaseErrorListener;
+import org.hibernate.sql.exec.internal.BaseExecutionContext;
+import org.springframework.http.HttpStatus;
+
+import static com.hackathon.wagle.domain.user.exception.ErrorMessage.USER_NOT_FOUND;
+import static org.springframework.http.HttpStatus.BAD_REQUEST;
+
+public class UserNotFoundException extends BaseException {
+    public UserNotFoundException() {
+        super(BAD_REQUEST, USER_NOT_FOUND.getMessage());
+    }
+}

--- a/src/main/java/com/hackathon/wagle/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/hackathon/wagle/domain/user/repository/UserRepository.java
@@ -1,0 +1,15 @@
+package com.hackathon.wagle.domain.user.repository;
+
+import com.hackathon.wagle.domain.user.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface UserRepository extends JpaRepository<User, Long> {
+
+    Optional<User> findByStudentNumber(String studentNumber);
+
+    Optional<User> findByEmail(String email);
+}

--- a/src/main/java/com/hackathon/wagle/domain/user/service/UserService.java
+++ b/src/main/java/com/hackathon/wagle/domain/user/service/UserService.java
@@ -1,11 +1,14 @@
 package com.hackathon.wagle.domain.user.service;
 
 import com.hackathon.wagle.domain.user.dto.request.UserRequestDto;
+import com.hackathon.wagle.domain.user.dto.request.UserLoginDto;
+import com.hackathon.wagle.domain.user.dto.response.LoginDto;
+import com.hackathon.wagle.domain.user.dto.response.UserResponseDto;
 import com.hackathon.wagle.domain.user.entity.User;
 import com.hackathon.wagle.domain.user.exception.DuplicatedStudentNumberException;
 import com.hackathon.wagle.domain.user.exception.UserNotFoundException;
 import com.hackathon.wagle.domain.user.repository.UserRepository;
-import com.hackathon.wagle.test.TestException;
+import com.hackathon.wagle.global.auth.jwt.utils.JwtProvider;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -15,6 +18,7 @@ import org.springframework.stereotype.Service;
 public class UserService {
 
     private final UserRepository userRepository;
+    private final JwtProvider jwtProvider;
 
     @Transactional
     public void saveUser(UserRequestDto dto) {
@@ -26,8 +30,31 @@ public class UserService {
         userRepository.save(user);
     }
 
+    public LoginDto login(UserLoginDto dto) {
+        User user = findByStudentNumber(dto.studentNumber());
+        String token = generateToken(user);
+
+        return LoginDto.of(UserResponseDto.from(user), token);
+    }
+
+
+    /*
+    * refactor
+    * */
+
+    public String generateToken(User user) {
+        return jwtProvider.generateAccessToken(
+                user.getId(), user.getEmail(), user.getRole().name()
+        );
+    }
+
     public User findById(Long id) {
         return userRepository.findById(id)
+                .orElseThrow(UserNotFoundException::new);
+    }
+
+    public User findByStudentNumber(String studentNumber) {
+        return userRepository.findByStudentNumber(studentNumber)
                 .orElseThrow(UserNotFoundException::new);
     }
 

--- a/src/main/java/com/hackathon/wagle/domain/user/service/UserService.java
+++ b/src/main/java/com/hackathon/wagle/domain/user/service/UserService.java
@@ -1,0 +1,44 @@
+package com.hackathon.wagle.domain.user.service;
+
+import com.hackathon.wagle.domain.user.dto.request.UserRequestDto;
+import com.hackathon.wagle.domain.user.entity.User;
+import com.hackathon.wagle.domain.user.exception.DuplicatedStudentNumberException;
+import com.hackathon.wagle.domain.user.exception.UserNotFoundException;
+import com.hackathon.wagle.domain.user.repository.UserRepository;
+import com.hackathon.wagle.test.TestException;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class UserService {
+
+    private final UserRepository userRepository;
+
+    @Transactional
+    public void saveUser(UserRequestDto dto) {
+        // 학번, 학교 이메일 유효성 검증
+        checkDuplicatedStuentNumber(dto.studentNumber());
+        checkDuplicatedEmail(dto.email());
+
+        User user = User.of(dto);
+        userRepository.save(user);
+    }
+
+    public User findById(Long id) {
+        return userRepository.findById(id)
+                .orElseThrow(UserNotFoundException::new);
+    }
+
+    private void checkDuplicatedStuentNumber(String studentNumber) {
+        userRepository.findByStudentNumber(studentNumber)
+                .ifPresent(user -> { throw new DuplicatedStudentNumberException(); });
+    }
+
+    private void checkDuplicatedEmail(String email) {
+        userRepository.findByEmail(email)
+                .ifPresent(user -> { throw new DuplicatedStudentNumberException(); });
+    }
+
+}

--- a/src/main/java/com/hackathon/wagle/global/auth/jwt/authentication/CustomAccessDeniedHandler.java
+++ b/src/main/java/com/hackathon/wagle/global/auth/jwt/authentication/CustomAccessDeniedHandler.java
@@ -1,0 +1,40 @@
+package com.hackathon.wagle.global.auth.jwt.authentication;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.hackathon.wagle.global.common.response.ApiResponse;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.web.access.AccessDeniedHandler;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+import static com.hackathon.wagle.global.auth.jwt.exception.ErrorMessage.JWT_TOKEN_FORBIDDEN;
+
+
+@Slf4j
+@Component
+public class CustomAccessDeniedHandler implements AccessDeniedHandler {
+
+    private final static String LOG_FORMAT = "ExceptionClass: {}, Message: {}";
+    private final static String CONTENT_TYPE = "application/json";
+    private final static String CHAR_ENCODING = "UTF-8";
+
+    @Override
+    public void handle(HttpServletRequest request, HttpServletResponse response, org.springframework.security.access.AccessDeniedException accessDeniedException) throws IOException, ServletException {
+        setResponse(response);
+        log.error(LOG_FORMAT, accessDeniedException.getClass().getSimpleName(), accessDeniedException.getMessage());
+    }
+
+    private void setResponse(HttpServletResponse response) throws IOException {
+        response.setStatus(HttpServletResponse.SC_FORBIDDEN);
+        response.setContentType(CONTENT_TYPE);
+        response.setCharacterEncoding(CHAR_ENCODING);
+
+        String body = new ObjectMapper().writeValueAsString(ApiResponse.response(HttpStatus.FORBIDDEN, JWT_TOKEN_FORBIDDEN.getMessage()));
+        response.getWriter().write(body);
+    }
+}

--- a/src/main/java/com/hackathon/wagle/global/auth/jwt/authentication/CustomAuthenticationEntryPoint.java
+++ b/src/main/java/com/hackathon/wagle/global/auth/jwt/authentication/CustomAuthenticationEntryPoint.java
@@ -1,0 +1,47 @@
+package com.hackathon.wagle.global.auth.jwt.authentication;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.hackathon.wagle.global.auth.jwt.exception.ErrorMessage;
+import com.hackathon.wagle.global.common.response.ApiResponse;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+
+@Slf4j
+@Component
+public class CustomAuthenticationEntryPoint implements AuthenticationEntryPoint {
+
+    private final static String LOG_FORMAT = "ExceptionClass: {}, Message: {}";
+    private final static String CONTENT_TYPE = "application/json";
+    private final static String CHAR_ENCODING = "UTF-8";
+
+    @Override
+    public void commence(HttpServletRequest request, HttpServletResponse response, AuthenticationException authException) throws IOException, ServletException {
+        ErrorMessage jwtError = (ErrorMessage) request.getAttribute("jwtError");
+
+        if (jwtError != null) {
+            setResponse(response, jwtError.getMessage());
+            log.error(LOG_FORMAT, jwtError, jwtError.getMessage());
+        } else {
+            setResponse(response, authException.getMessage());
+            log.error(LOG_FORMAT, authException.getClass().getSimpleName(), authException.getMessage());
+        }
+    }
+
+    private void setResponse(HttpServletResponse response, String message) throws IOException {
+        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+        response.setContentType(CONTENT_TYPE);
+        response.setCharacterEncoding(CHAR_ENCODING);
+
+        String body = new ObjectMapper().writeValueAsString(ApiResponse.response(HttpStatus.UNAUTHORIZED, message));
+        response.getWriter().write(body);
+    }
+}

--- a/src/main/java/com/hackathon/wagle/global/auth/jwt/exception/ErrorMessage.java
+++ b/src/main/java/com/hackathon/wagle/global/auth/jwt/exception/ErrorMessage.java
@@ -1,0 +1,18 @@
+package com.hackathon.wagle.global.auth.jwt.exception;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum ErrorMessage {
+
+    REFRESH_TOKEN_NOT_MATCH("[RefreshToken]이 [Redis]에 저장된 토큰과 다릅니다"),
+    REFRESH_TOKEN_EXPIRED("[RefreshToken]이 만료됐습니다"),
+    ACCESS_TOKEN_EXPIRED("[AccessToken]이 만료됐습니다"),
+    ACCESS_TOKEN_NOT_FOUND("[AccessToken]을 찾을 수 없습니다"),
+    JWT_TOKEN_FORBIDDEN("[Token]에 올바른 권한이 없습니다."),
+    JWT_TOKEN_INVALID("유효한 [Token]이 아닙니다.");
+
+    private final String message;
+}

--- a/src/main/java/com/hackathon/wagle/global/auth/jwt/exception/TokenInvalidException.java
+++ b/src/main/java/com/hackathon/wagle/global/auth/jwt/exception/TokenInvalidException.java
@@ -1,0 +1,14 @@
+package com.hackathon.wagle.global.auth.jwt.exception;
+
+
+import com.hackathon.wagle.global.common.exception.BaseException;
+
+import static com.hackathon.wagle.global.auth.jwt.exception.ErrorMessage.JWT_TOKEN_INVALID;
+import static org.springframework.http.HttpStatus.BAD_REQUEST;
+
+public class TokenInvalidException extends BaseException {
+
+    public TokenInvalidException() {
+        super(BAD_REQUEST, JWT_TOKEN_INVALID.getMessage());
+    }
+}

--- a/src/main/java/com/hackathon/wagle/global/auth/jwt/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/hackathon/wagle/global/auth/jwt/filter/JwtAuthenticationFilter.java
@@ -1,0 +1,66 @@
+package com.hackathon.wagle.global.auth.jwt.filter;
+
+import com.hackathon.wagle.global.auth.jwt.user.JwtUserDetails;
+import com.hackathon.wagle.global.auth.jwt.utils.JwtExtractor;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.util.Optional;
+
+import static com.hackathon.wagle.global.auth.jwt.exception.ErrorMessage.*;
+
+
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+    private final JwtExtractor jwtExtractor;
+
+    public static final String JWT_ERROR = "jwtError";
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+        Optional<String> token = jwtExtractor.extractJwtToken(request);
+
+        if (token.isEmpty()) {
+            request.setAttribute(JWT_ERROR, ACCESS_TOKEN_NOT_FOUND);
+            filterChain.doFilter(request, response);
+            return;
+        }
+
+        String accessToken = token.get();
+        if(!jwtExtractor.validateJwtToken(accessToken)) {
+            request.setAttribute(JWT_ERROR, JWT_TOKEN_INVALID);
+            filterChain.doFilter(request, response);
+            return;
+        }
+
+        if(jwtExtractor.isExpired(accessToken)) {
+            request.setAttribute(JWT_ERROR, ACCESS_TOKEN_EXPIRED);
+            filterChain.doFilter(request, response);
+            return;
+        }
+
+        saveAuthentication(accessToken);
+        filterChain.doFilter(request, response);
+    }
+
+    private void saveAuthentication(String accessToken) {
+        Long id = jwtExtractor.getId(accessToken);
+        String email = jwtExtractor.getEmail(accessToken);
+        String role = jwtExtractor.getRole(accessToken);
+
+        UserDetails userDetails = JwtUserDetails.of(id, email, role);
+        Authentication authentication = new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities());
+        SecurityContextHolder.getContext().setAuthentication(authentication);
+    }
+}

--- a/src/main/java/com/hackathon/wagle/global/auth/jwt/user/JwtUserDetails.java
+++ b/src/main/java/com/hackathon/wagle/global/auth/jwt/user/JwtUserDetails.java
@@ -1,0 +1,26 @@
+package com.hackathon.wagle.global.auth.jwt.user;
+
+import lombok.Getter;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.User;
+
+import java.util.Collections;
+import java.util.List;
+
+@Getter
+public class JwtUserDetails extends User {
+
+    private final Long id;
+    private final String role;
+
+    public JwtUserDetails(Long id, String email, List<GrantedAuthority> authorities, String role) {
+        super(email, "", authorities);
+        this.id = id;
+        this.role = role;
+    }
+
+    public static JwtUserDetails of(Long id, String email, String role) {
+        return new JwtUserDetails(id, email, Collections.singletonList(new SimpleGrantedAuthority(role)), role);
+    }
+}

--- a/src/main/java/com/hackathon/wagle/global/auth/jwt/utils/JwtExtractor.java
+++ b/src/main/java/com/hackathon/wagle/global/auth/jwt/utils/JwtExtractor.java
@@ -1,0 +1,89 @@
+package com.hackathon.wagle.global.auth.jwt.utils;
+
+import com.hackathon.wagle.global.auth.jwt.exception.TokenInvalidException;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.JwtException;
+import io.jsonwebtoken.JwtParser;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.Keys;
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import java.security.Key;
+import java.util.Date;
+import java.util.Optional;
+
+import static com.hackathon.wagle.global.auth.jwt.utils.JwtProvider.ACCESS_TOKEN_SUBJECT;
+
+@Component
+public class JwtExtractor {
+
+
+    private static final String BEARER = "Bearer ";
+    private static final String ID_CLAIM = "id";
+    private static final String EMAIL_CLAIM = "email";
+    private static final String ROLE_CLAIM = "role";
+
+    private final Key key;
+
+    public JwtExtractor(@Value("${wagle.auth.jwt.key}") String secretKey) {
+        this.key = Keys.hmacShaKeyFor(secretKey.getBytes()); // 키 변환
+    }
+
+    public Optional<String> extractJwtToken(HttpServletRequest request) {
+        return Optional.ofNullable(request.getHeader(ACCESS_TOKEN_SUBJECT))
+                .filter(refreshToken -> refreshToken.startsWith(BEARER))
+                .map(refreshToken -> refreshToken.replace(BEARER, ""));
+    }
+
+    public Long getId(String token){
+        return getIdFromToken(token, ID_CLAIM);
+    }
+
+    public String getEmail(String token){
+        return getClaimFromToken(token, EMAIL_CLAIM);
+    }
+
+    public String getRole(String token) {
+        return getClaimFromToken(token, ROLE_CLAIM);
+    }
+
+    public Boolean isExpired(String token) {
+        Claims claims = parseClaims(token);
+        return claims.getExpiration().before(new Date());
+    }
+
+    private String getClaimFromToken(String token, String claimName) {
+        Claims claims = parseClaims(token);
+        return claims.get(claimName, String.class);
+    }
+
+    private Long getIdFromToken(String token, String claimName) {
+        Claims claims = parseClaims(token);
+        return claims.get(claimName, Long.class);
+    }
+
+    private Claims parseClaims(String token) {
+        try{
+            JwtParser parser = Jwts.parserBuilder()
+                    .setSigningKey(key)
+                    .build();
+            return parser.parseClaimsJws(token).getBody();
+        }catch (JwtException e){
+            throw new TokenInvalidException();
+        }
+    }
+
+    public boolean validateJwtToken(String token) {
+        try{
+            JwtParser parser = Jwts.parserBuilder()
+                    .setSigningKey(key)
+                    .build();
+            parser.parseClaimsJws(token).getBody();
+            return true;
+        }catch (JwtException e){
+            return false;
+        }
+    }
+}

--- a/src/main/java/com/hackathon/wagle/global/auth/jwt/utils/JwtProvider.java
+++ b/src/main/java/com/hackathon/wagle/global/auth/jwt/utils/JwtProvider.java
@@ -1,0 +1,41 @@
+package com.hackathon.wagle.global.auth.jwt.utils;
+
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.security.Keys;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import java.security.Key;
+import java.util.Date;
+
+@Component
+public class JwtProvider {
+
+    public static final String ACCESS_TOKEN_SUBJECT = "Authorization";
+    private static final String ID_CLAIM = "id";
+    private static final String EMAIL_CLAIM = "email";
+    private static final String ROLE_CLAIM = "role";
+    private static final String ROLE_PREFIX = "ROLE_";
+    private static final String DUMMY_EMAIL = "dummy_email";
+    private final Key key;
+
+    public JwtProvider(@Value("${wagle.auth.jwt.key}") String secretKey) {
+        this.key = Keys.hmacShaKeyFor(secretKey.getBytes()); // 키 변환
+    }
+
+    @Value("${wagle.auth.jwt.accessTokenExpiration}")
+    private Long accessTokenExpiration;
+
+    public String generateAccessToken(Long id, String email, String role) {
+        return Jwts.builder()
+                .claim(ID_CLAIM, id)
+                .claim(EMAIL_CLAIM, email)
+                .claim(ROLE_CLAIM, ROLE_PREFIX+role)
+                .setSubject(ACCESS_TOKEN_SUBJECT) // 사용자 정보(고유 식별자)
+                .setIssuedAt(new Date()) // 발행 시간
+                .setExpiration(new Date(System.currentTimeMillis() + accessTokenExpiration)) // 만료 시간
+                .signWith(key, SignatureAlgorithm.HS256) // 서명 알고리즘
+                .compact(); // 최종 문자열 생성
+    }
+}

--- a/src/main/java/com/hackathon/wagle/global/common/entity/BaseEntity.java
+++ b/src/main/java/com/hackathon/wagle/global/common/entity/BaseEntity.java
@@ -1,0 +1,31 @@
+package com.hackathon.wagle.global.common.entity;
+
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Getter
+@MappedSuperclass
+@SuperBuilder
+@NoArgsConstructor
+@EntityListeners(AuditingEntityListener.class)
+public abstract class BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @CreatedDate
+    @Column(updatable = false)
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    private LocalDateTime updatedAt;
+}

--- a/src/main/java/com/hackathon/wagle/global/config/PermitUrlConfig.java
+++ b/src/main/java/com/hackathon/wagle/global/config/PermitUrlConfig.java
@@ -1,0 +1,20 @@
+package com.hackathon.wagle.global.config;
+
+import org.springframework.stereotype.Component;
+
+@Component
+public class PermitUrlConfig {
+
+    public String[] getPublicUrl(){
+        return new String[]{
+                "/api/user",
+                "/api/login",
+        };
+    }
+
+    public String[] getMemberUrl(){
+        return new String[]{
+                "/api/member/**"
+        };
+    }
+}

--- a/src/main/java/com/hackathon/wagle/global/config/SecurityConfig.java
+++ b/src/main/java/com/hackathon/wagle/global/config/SecurityConfig.java
@@ -1,0 +1,81 @@
+package com.hackathon.wagle.global.config;
+
+import com.hackathon.wagle.global.auth.jwt.authentication.CustomAccessDeniedHandler;
+import com.hackathon.wagle.global.auth.jwt.authentication.CustomAuthenticationEntryPoint;
+import com.hackathon.wagle.global.auth.jwt.filter.JwtAuthenticationFilter;
+import com.hackathon.wagle.global.auth.jwt.utils.JwtExtractor;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static com.hackathon.wagle.domain.user.entity.enums.Role.ADMIN;
+import static com.hackathon.wagle.domain.user.entity.enums.Role.MEMBER;
+
+@Configuration
+@EnableWebSecurity
+@RequiredArgsConstructor
+@EnableMethodSecurity(prePostEnabled = true)
+public class SecurityConfig {
+
+    private final PermitUrlConfig permitUrlConfig;
+    private final CustomAuthenticationEntryPoint customAuthenticationEntryPoint;
+    private final CustomAccessDeniedHandler customAccessDeniedHandler;
+    private final JwtExtractor jwtExtractor;
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        http
+                .formLogin(AbstractHttpConfigurer::disable)
+                .httpBasic(AbstractHttpConfigurer::disable)
+                .cors(cors -> cors.configurationSource(corsConfigurationSource()))
+                .csrf(AbstractHttpConfigurer::disable)
+                .sessionManagement(AbstractHttpConfigurer::disable);
+
+        http.authorizeHttpRequests((auth) -> auth
+                .requestMatchers(permitUrlConfig.getPublicUrl()).permitAll()
+                .requestMatchers(permitUrlConfig.getMemberUrl()).hasAnyRole(MEMBER.name(), ADMIN.name())
+                .anyRequest().authenticated());
+
+        http.exceptionHandling(e -> e
+                .authenticationEntryPoint(customAuthenticationEntryPoint)
+                .accessDeniedHandler(customAccessDeniedHandler));
+        http.addFilterBefore(new JwtAuthenticationFilter(jwtExtractor), UsernamePasswordAuthenticationFilter.class);
+
+        return http.build();
+    }
+
+    @Bean
+    public AuthenticationManager authenticationManager(AuthenticationConfiguration configuration) throws Exception {
+        return configuration.getAuthenticationManager();
+    }
+
+    @Bean
+    public CorsConfigurationSource corsConfigurationSource() {
+        CorsConfiguration configuration = new CorsConfiguration();
+        configuration.setAllowedOriginPatterns(List.of("*"));
+        configuration.setAllowedMethods(Arrays.asList("GET", "POST", "PATCH", "DELETE", "OPTIONS"));
+        configuration.setAllowedHeaders(Arrays.asList("*"));
+        configuration.setExposedHeaders(Arrays.asList("Authorization", "Set-Cookie"));
+        configuration.setAllowCredentials(true);
+
+        // /** 들어오는 모든 유형의 URL 패턴을 허용.
+        UrlBasedCorsConfigurationSource urlBasedCorsConfigurationSource = new UrlBasedCorsConfigurationSource();
+        urlBasedCorsConfigurationSource.registerCorsConfiguration("/**", configuration);
+        return urlBasedCorsConfigurationSource;
+    }
+
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -11,3 +11,9 @@ spring:
         dialect: org.hibernate.dialect.MySQLDialect
     hibernate:
       ddl-auto: update
+
+wagle:
+  auth:
+    jwt:
+      key: ${JWT_SECRET_KEY}
+      accessTokenExpiration: ${JWT_ACCESS_TOKEN_EXPIRATION}


### PR DESCRIPTION
## #️⃣연관된 이슈
> ex)
관련 이슈 번호 #3 
Close #3

## 📝작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

자체 로그인을 구현했습니다.
1. 사용자 경험에서 회원가입 단계 플로우를 줄이기 위함.
2. 한 명인 프론트의 부담을 줄이기 위함.

위와 같은 이유로 자체 로그인을 택해 구현했습니다.

회원가입, 로그인을 제외한 모든 요청에 Token을 포함해서 보내주시면 됩니다!


## 스크린샷 (선택)

